### PR TITLE
Add Flask web UI for Kandinsky image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,25 @@ cd src
 python3 main.py
 ```
 
+### Run the Flask web demo
+
+Launch the lightweight UI to enter prompts manually:
+
+```bash
+cd ~/Desktop/auto_gen
+source venv/bin/activate
+pip install -r REQUIREMENTS.txt
+cd src
+python app.py
+```
+
+Then browse to [http://127.0.0.1:5000/](http://127.0.0.1:5000/) and submit a prompt. The server will run
+`generate_image(prompt)` behind the scenes, write the output to `static/out.png`, and the page refresh will
+display the newly generated (or placeholder) artwork.
+
 Running the command will download the Kandinsky 2.2 decoder from Hugging Face if it is not already cached. The script writes its outputs to the `src/` directory:
 
-- `out.png` – the generated image from the Kandinsky pipeline.
+- `static/out.png` – the generated image from the Kandinsky pipeline.
 - `out.mp4` – a short video clip stitched from the generated image.
 
 If CUDA is available the pipeline will automatically move to the GPU; otherwise it runs entirely on the CPU without further configuration.

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -10,3 +10,4 @@ openai==1.35.10
 python-dotenv==1.0.1
 Pillow==10.3.0
 requests==2.32.3
+Flask==3.0.3

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,81 @@
+"""Flask application exposing a simple text-to-image demo."""
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Optional
+
+from flask import Flask, render_template, request, url_for
+
+from image_gen import generate_image
+
+
+BASE_DIR = Path(__file__).resolve().parent
+STATIC_DIR = BASE_DIR / "static"
+DEFAULT_IMAGE = STATIC_DIR / "out.png"
+
+
+def _ensure_static_dir(path: Path) -> Path:
+    """Guarantee that the static directory exists before writes."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+_ensure_static_dir(DEFAULT_IMAGE)
+
+app = Flask(
+    __name__,
+    template_folder=str(BASE_DIR / "templates"),
+    static_folder=str(STATIC_DIR),
+)
+app.config["TEMPLATES_AUTO_RELOAD"] = True
+
+logger = logging.getLogger(__name__)
+
+
+@app.route("/", methods=["GET", "POST"])
+def index() -> str:
+    """Render the home page, generating an image when the form is submitted."""
+    prompt_value = ""
+    image_url: Optional[str] = None
+    error_message: Optional[str] = None
+
+    if request.method == "POST":
+        prompt_value = request.form.get("prompt", "").strip()
+        if not prompt_value:
+            error_message = "Please provide a prompt before generating an image."
+        else:
+            try:
+                image_path = Path(generate_image(prompt_value))
+                if not image_path.exists():
+                    raise FileNotFoundError(image_path)
+                # Bust browser cache by appending timestamp query parameter.
+                cache_buster = int(time.time())
+                image_url = url_for("static", filename=image_path.name) + f"?v={cache_buster}"
+            except Exception as exc:  # pragma: no cover - runtime feedback for UI
+                logger.exception("Image generation failed: %s", exc)
+                error_message = "Unable to generate image. Please try again."
+
+    # Display the most recent image even when the request is GET only.
+    if image_url is None and DEFAULT_IMAGE.exists():
+        cache_buster = int(time.time())
+        image_url = url_for("static", filename=DEFAULT_IMAGE.name) + f"?v={cache_buster}"
+
+    return render_template(
+        "index.html",
+        prompt_value=prompt_value,
+        image_url=image_url,
+        error_message=error_message,
+    )
+
+
+@app.route("/health", methods=["GET"])
+def healthcheck() -> tuple[str, int]:
+    """Simple health endpoint useful for diagnostics."""
+    return "ok", 200
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI execution
+    logging.basicConfig(level=logging.INFO)
+    app.run(host="127.0.0.1", port=5000, debug=False)

--- a/src/image_gen.py
+++ b/src/image_gen.py
@@ -43,6 +43,9 @@ logger = logging.getLogger(__name__)
 
 PIPELINE_ID = "kandinsky-community/kandinsky-2-2-decoder"
 
+BASE_DIR = Path(__file__).resolve().parent
+DEFAULT_OUTPUT_PATH = (BASE_DIR / "static" / "out.png").resolve()
+
 
 @lru_cache(maxsize=1)
 def get_T2I_pipeline() -> "KandinskyV22Pipeline":
@@ -153,16 +156,12 @@ def _generate_with_kandinsky(prompt: str, output_path: Path, device: str) -> Opt
     return saved_path
 
 
-def generate_image(
-    prompt: str, output_path: str, device: Optional[str] = "auto"
-) -> str:
-    """Generate an image using the Kandinsky 2.2 pipeline and persist it to disk."""
+def generate_image(prompt: str, device: Optional[str] = "auto") -> str:
+    """Generate an image and persist it to the default static output path."""
     if not isinstance(prompt, str) or not prompt.strip():
         raise ValueError("prompt must be a non-empty string.")
-    if not isinstance(output_path, str) or not output_path.strip():
-        raise ValueError("output_path must be a non-empty string path.")
 
-    output_file = _ensure_output_path(Path(output_path).expanduser().resolve())
+    output_file = _ensure_output_path(DEFAULT_OUTPUT_PATH)
     if device is not None and not isinstance(device, str):
         raise ValueError("device must be a string identifier or None.")
 

--- a/src/main.py
+++ b/src/main.py
@@ -63,12 +63,12 @@ def run(topic: str = "daily productivity tips") -> Dict[str, Any]:
         logger.error("Prompt generation failed: %s", exc)
     result["prompt"] = prompt_text
 
-    image_output = BASE_DIR / "out.png"
     try:
-        image_path = Path(generate_image(prompt_text, str(image_output)))
+        image_path = Path(generate_image(prompt_text))
     except Exception as exc:
         logger.error("Image generation failed: %s", exc)
-        image_path = Path(_fallback_image(image_output, prompt_text))
+        fallback_output = BASE_DIR / "static" / "out.png"
+        image_path = Path(_fallback_image(fallback_output, prompt_text))
     result["image_path"] = str(image_path)
 
     video_output = BASE_DIR / "out.mp4"

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Kandinsky Image Generator</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      body {
+        margin: 0;
+        font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+        background: radial-gradient(circle at top, #1e293b, #020617 65%);
+        color: #f8fafc;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      main {
+        width: min(960px, 90vw);
+        padding: 2.5rem;
+        background: rgba(15, 23, 42, 0.85);
+        border-radius: 24px;
+        box-shadow: 0 24px 48px rgba(2, 6, 23, 0.4);
+      }
+      h1 {
+        margin-top: 0;
+        text-align: center;
+        font-size: 2.25rem;
+        letter-spacing: 0.04em;
+      }
+      form {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        margin-bottom: 2rem;
+      }
+      label {
+        font-weight: 600;
+        letter-spacing: 0.03em;
+      }
+      input[type="text"] {
+        padding: 0.85rem 1rem;
+        border-radius: 12px;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: rgba(15, 23, 42, 0.75);
+        color: inherit;
+        font-size: 1rem;
+      }
+      input[type="text"]:focus {
+        outline: 3px solid rgba(56, 189, 248, 0.45);
+        border-color: rgba(56, 189, 248, 0.6);
+      }
+      button {
+        align-self: flex-start;
+        padding: 0.85rem 1.6rem;
+        border-radius: 999px;
+        border: none;
+        font-weight: 600;
+        font-size: 1rem;
+        cursor: pointer;
+        background: linear-gradient(120deg, #38bdf8, #818cf8);
+        color: #0f172a;
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+      }
+      button:hover,
+      button:focus-visible {
+        transform: translateY(-1px);
+        box-shadow: 0 10px 30px rgba(129, 140, 248, 0.4);
+      }
+      button:focus-visible {
+        outline: 3px solid rgba(148, 163, 184, 0.5);
+        outline-offset: 4px;
+      }
+      .preview {
+        display: grid;
+        gap: 1rem;
+        justify-items: center;
+        text-align: center;
+      }
+      .preview img {
+        width: min(512px, 100%);
+        border-radius: 18px;
+        box-shadow: 0 18px 36px rgba(15, 23, 42, 0.6);
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        background: rgba(15, 23, 42, 0.6);
+      }
+      .alert {
+        padding: 0.75rem 1rem;
+        border-radius: 12px;
+        background: rgba(248, 113, 113, 0.2);
+        color: #fecaca;
+        border: 1px solid rgba(248, 113, 113, 0.45);
+      }
+      @media (max-width: 640px) {
+        main {
+          padding: 1.75rem;
+        }
+        h1 {
+          font-size: 1.75rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Kandinsky Image Generator</h1>
+      <form method="post" aria-label="Generate an image from a text prompt">
+        <label for="prompt">Describe the image you want to see</label>
+        <input
+          id="prompt"
+          name="prompt"
+          type="text"
+          value="{{ prompt_value }}"
+          placeholder="e.g. A serene landscape with neon auroras"
+          required
+          aria-required="true"
+        />
+        <button type="submit">Generate image</button>
+      </form>
+      {% if error_message %}
+      <div class="alert" role="alert">{{ error_message }}</div>
+      {% endif %}
+      <section class="preview" aria-live="polite">
+        {% if image_url %}
+        <img src="{{ image_url }}" alt="Generated artwork for the prompt" />
+        {% else %}
+        <p>The generated artwork will appear here.</p>
+        {% endif %}
+      </section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a Flask server entry point and HTML template that accepts prompts and renders generated images
- update the image generation helper and orchestrator to persist results to `src/static/out.png`
- document the local UI workflow and include Flask in the Python requirements

## Testing
- python -m compileall src
- python app.py *(fails: Flask cannot be installed in the execution environment due to restricted network access)*

------
https://chatgpt.com/codex/tasks/task_e_68dfad61e3888330aa988595052f2c43