### PR TITLE
Update docs to stop referencing Kandinsky-3 source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 Goal: Local desktop pipeline that generates social content automatically.
-Flow: Topic → Text Prompt → Kandinsky-3 Image → Video Stitch → Post to Socials.
+Flow: Topic → Text Prompt → Kandinsky Image → Video Stitch → Post to Socials.
 
 Each agent works in its own branch, submits a PR, then Stitcher merges.
 
@@ -18,7 +18,7 @@ Each agent works in its own branch, submits a PR, then Stitcher merges.
 
 ### Agent 2: Image Generator
 - File: `src/image_gen.py`
-- Task: Wrap Kandinsky-3 (`get_T2I_pipeline`) to produce PNG from text.
+- Task: Wrap the Hugging Face Kandinsky pipeline (`get_T2I_pipeline`) to produce PNG from text.
 - Save file path and return.
 - Expose `generate_image(prompt: str, output_path: str) -> str`.
 


### PR DESCRIPTION
## Summary
- remove the mention of the old Kandinsky-3 source folder from the agent instructions
- document that the image generator relies on the Hugging Face Kandinsky pipeline already present in the repo

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68dfb9ff08408330bb1eaad01aa2d60e